### PR TITLE
Remove icon generator config from composer releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 
 /.github export-ignore
 /bin export-ignore
+/config/generation.php export-ignore
 /dist export-ignore
 /tests export-ignore
 .gitattributes export-ignore


### PR DESCRIPTION
The icon generator should only be used when the icon package (ie `blade-fontawesome-icons`) is the root project. So when the icon package is consumed by a different package the generation config isn't needed. So we can ignore generation config as it's not used at runtime for icon package consumers.